### PR TITLE
Add default constructor to PointSurface

### DIFF
--- a/src/org/opensha/sha/faultSurface/PointSurface.java
+++ b/src/org/opensha/sha/faultSurface/PointSurface.java
@@ -111,6 +111,15 @@ public class PointSurface implements RuptureSurface, java.io.Serializable{
 		setLocation(loc);
 	}
 
+	/**
+	 *  Constructor for the PointSurface object. Sets all the fields
+	 *  for a Location object.
+	 *
+	 *  OAF needs to have a default constructor.
+	 */
+	public PointSurface() {
+		setLocation(null);
+	}
 
 	/**
 	 * Sets the average strike of this surface on the Earth. An InvalidRangeException


### PR DESCRIPTION
Add a default constructor to the class org.opensha.sha.faultSurface.PointSurface. This is required for OAF.
