### PR TITLE
added new quick dist method to RuptureSurface & caches

### DIFF
--- a/src/org/opensha/sha/faultSurface/AbstractEvenlyGriddedSurface.java
+++ b/src/org/opensha/sha/faultSurface/AbstractEvenlyGriddedSurface.java
@@ -244,6 +244,16 @@ implements EvenlyGriddedSurface, CacheEnabledSurface, Serializable {
 	}
 	
 	@Override
+	public double getQuickDistance(Location siteLoc) {
+		return cache.getQuickDistance(siteLoc);
+	}
+
+	@Override
+	public double calcQuickDistance(Location siteLoc) {
+		return GriddedSurfaceUtils.getCornerMidpointDistance(this, siteLoc);
+	}
+
+	@Override
 	public double calcDistanceX(Location siteLoc) {
 		return GriddedSurfaceUtils.getDistanceX(getEvenlyDiscritizedUpperEdge(), siteLoc);
 	}

--- a/src/org/opensha/sha/faultSurface/CompoundSurface.java
+++ b/src/org/opensha/sha/faultSurface/CompoundSurface.java
@@ -291,6 +291,20 @@ public class CompoundSurface implements RuptureSurface, CacheEnabledSurface {
 	public double getDistanceRup(Location siteLoc) {
 		return cache.getSurfaceDistances(siteLoc).getDistanceRup();
 	}
+	
+	@Override
+	public double getQuickDistance(Location siteLoc) {
+		return cache.getQuickDistance(siteLoc);
+	}
+
+
+	@Override
+	public double calcQuickDistance(Location siteLoc) {
+		double minDist = Double.POSITIVE_INFINITY;
+		for (RuptureSurface surf : surfaces)
+			minDist = Math.min(minDist, surf.getQuickDistance(siteLoc));
+		return minDist;
+	}
 
 	@Override
 	public double getDistanceSeis(Location siteLoc) {

--- a/src/org/opensha/sha/faultSurface/GriddedSubsetSurface.java
+++ b/src/org/opensha/sha/faultSurface/GriddedSubsetSurface.java
@@ -28,6 +28,7 @@ import org.opensha.commons.data.Window2D;
 import org.opensha.commons.geo.BorderType;
 import org.opensha.commons.geo.Location;
 import org.opensha.commons.geo.LocationList;
+import org.opensha.commons.geo.LocationUtils;
 import org.opensha.commons.geo.LocationVector;
 import org.opensha.commons.geo.Region;
 import org.opensha.sha.faultSurface.cache.CacheEnabledSurface;
@@ -271,6 +272,16 @@ public class GriddedSubsetSurface extends ContainerSubset2D<Location>  implement
 	public SurfaceDistances calcDistances(Location loc) {
 		double[] dCalc = GriddedSurfaceUtils.getPropagationDistances(this, loc);
 		return new SurfaceDistances(dCalc[0], dCalc[1], dCalc[2]);
+	}
+	
+	@Override
+	public double getQuickDistance(Location siteLoc) {
+		return cache.getQuickDistance(siteLoc);
+	}
+
+	@Override
+	public double calcQuickDistance(Location siteLoc) {
+		return GriddedSurfaceUtils.getCornerMidpointDistance(this, siteLoc);
 	}
 
 	@Override

--- a/src/org/opensha/sha/faultSurface/PointSurface.java
+++ b/src/org/opensha/sha/faultSurface/PointSurface.java
@@ -306,6 +306,11 @@ public class PointSurface implements RuptureSurface, java.io.Serializable{
 		double djb = getDistanceJB(siteLoc);
 		return Math.sqrt(depth * depth + djb * djb);
 	}
+	
+	@Override
+	public double getQuickDistance(Location siteLoc) {
+		return getDistanceRup(siteLoc);
+	}
 
 	/**
 	 * This returns distance X (the shortest distance in km to the rupture 

--- a/src/org/opensha/sha/faultSurface/RuptureSurface.java
+++ b/src/org/opensha/sha/faultSurface/RuptureSurface.java
@@ -98,6 +98,15 @@ public interface RuptureSurface extends Surface3D {
 	 * @return
 	 */
 	public double getAveGridSpacing();
+	
+	/**
+	 * This returns a quick but inaccurate distance (km) between the site location and 
+	 * this surface. Implementation details vary by source, but this is typically the
+	 * minimum distance to the corners or midpoint of the surface.
+	 * @param siteLoc
+	 * @return
+	 */
+	public double getQuickDistance(Location siteLoc);
 		
 	/**
 	 * This returns rupture distance (kms to closest point on the 

--- a/src/org/opensha/sha/faultSurface/cache/CacheEnabledSurface.java
+++ b/src/org/opensha/sha/faultSurface/cache/CacheEnabledSurface.java
@@ -18,6 +18,14 @@ public interface CacheEnabledSurface extends RuptureSurface {
 	public SurfaceDistances calcDistances(Location loc);
 	
 	/**
+	 * Calculates the quick distance for the given location without any caching, used by a loading cache
+	 * 
+	 * @param loc
+	 * @return
+	 */
+	public double calcQuickDistance(Location loc);
+	
+	/**
 	 * Calculates distance X directly without any caching, used by a loading cache.
 	 * @param loc
 	 * @return

--- a/src/org/opensha/sha/faultSurface/cache/DisabledDistanceCache.java
+++ b/src/org/opensha/sha/faultSurface/cache/DisabledDistanceCache.java
@@ -30,4 +30,9 @@ class DisabledDistanceCache implements SurfaceDistanceCache {
 		// do nothing
 	}
 
+	@Override
+	public double getQuickDistance(Location loc) {
+		return surf.calcQuickDistance(loc);
+	}
+
 }

--- a/src/org/opensha/sha/faultSurface/cache/HybridDistanceCache.java
+++ b/src/org/opensha/sha/faultSurface/cache/HybridDistanceCache.java
@@ -43,6 +43,18 @@ public class HybridDistanceCache implements SurfaceDistanceCache {
 	}
 
 	@Override
+	public double getQuickDistance(Location loc) {
+		Double quickDist = singleCache.getQuickDistanceIfPresent(loc);
+		if (quickDist != null)
+			return quickDist;
+		// not in single cache, get from multi cache (load if necessary)
+		quickDist = multiCache.getQuickDistance(loc);
+		// put in single cache
+		singleCache.putQuickDistance(loc, quickDist);
+		return quickDist;
+	}
+
+	@Override
 	public double getDistanceX(Location loc) {
 		Double distX = singleCache.getDistanceXIfPresent(loc);
 		if (distX != null)

--- a/src/org/opensha/sha/faultSurface/cache/SingleLocDistanceCache.java
+++ b/src/org/opensha/sha/faultSurface/cache/SingleLocDistanceCache.java
@@ -15,6 +15,9 @@ public class SingleLocDistanceCache implements SurfaceDistanceCache {
 	private Location siteLocForDistCalcs;
 	private SurfaceDistances surfDists;
 	
+	private Location siteLocForQuickDistCalc;
+	private double quickDist;
+	
 	private Location siteLocForDistXCalc;
 	private double distX;
 	
@@ -32,6 +35,15 @@ public class SingleLocDistanceCache implements SurfaceDistanceCache {
 	}
 
 	@Override
+	public synchronized double getQuickDistance(Location loc) {
+		if (siteLocForQuickDistCalc == null || !siteLocForQuickDistCalc.equals(loc)) {
+			quickDist = surf.calcQuickDistance(loc);
+			siteLocForQuickDistCalc = loc;
+		}
+		return quickDist;
+	}
+
+	@Override
 	public synchronized double getDistanceX(Location loc) {
 		if (siteLocForDistXCalc == null || !siteLocForDistXCalc.equals(loc)) {
 			distX = surf.calcDistanceX(loc);
@@ -46,6 +58,12 @@ public class SingleLocDistanceCache implements SurfaceDistanceCache {
 		return null;
 	}
 	
+	synchronized Double getQuickDistanceIfPresent(Location loc) {
+		if (loc.equals(siteLocForQuickDistCalc))
+			return quickDist;
+		return null;
+	}
+	
 	synchronized Double getDistanceXIfPresent(Location loc) {
 		if (loc.equals(siteLocForDistXCalc))
 			return distX;
@@ -55,6 +73,11 @@ public class SingleLocDistanceCache implements SurfaceDistanceCache {
 	synchronized void putSurfaceDistances(Location loc, SurfaceDistances dists) {
 		this.siteLocForDistCalcs = loc;
 		this.surfDists = dists;
+	}
+	
+	synchronized void putQuickDistance(Location loc, double quickDistance) {
+		this.siteLocForQuickDistCalc = loc;
+		this.quickDist = quickDistance;
 	}
 	
 	synchronized void putDistanceX(Location loc, double distX) {
@@ -68,6 +91,8 @@ public class SingleLocDistanceCache implements SurfaceDistanceCache {
 		this.surfDists = null;
 		this.siteLocForDistXCalc = null;
 		this.distX = Double.NaN;
+		siteLocForQuickDistCalc = null;
+		this.quickDist = Double.NaN;
 	}
 
 }

--- a/src/org/opensha/sha/faultSurface/cache/SurfaceDistanceCache.java
+++ b/src/org/opensha/sha/faultSurface/cache/SurfaceDistanceCache.java
@@ -23,6 +23,14 @@ public interface SurfaceDistanceCache {
 	public SurfaceDistances getSurfaceDistances(Location loc);
 	
 	/**
+	 * Returns the quick distance for the given location, either from the cache or via calculation.
+	 * 
+	 * @param loc
+	 * @return
+	 */
+	public double getQuickDistance(Location loc);
+	
+	/**
 	 * Returns the distance X value for the given location, either from the cache or via calculation.
 	 * 
 	 * @param loc

--- a/src/org/opensha/sha/faultSurface/utils/GriddedSurfaceUtils.java
+++ b/src/org/opensha/sha/faultSurface/utils/GriddedSurfaceUtils.java
@@ -3,6 +3,7 @@ package org.opensha.sha.faultSurface.utils;
 import java.awt.Color;
 import java.awt.geom.Area;
 import java.awt.geom.Path2D;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -538,7 +539,36 @@ public class GriddedSurfaceUtils {
 	}
 	
 	/**
-	 * Gents the center location of this surface. If it implements EvenlyGriddedSurface and has 3 or more
+	 * Calculates a quick the distance to the this surface by taking the minimum distance
+	 * to the corners, middle of the upper and lower traces, and overall center point
+	 * @param surf
+	 * @param siteLoc
+	 * @return
+	 */
+	public static double getCornerMidpointDistance(EvenlyGriddedSurface surf, Location siteLoc) {
+		double minDist = Double.POSITIVE_INFINITY;
+		
+		int numRows = surf.getNumRows();
+		int numCols = surf.getNumCols();
+		
+		List<Location> quickLocs = new ArrayList<>();
+		quickLocs.add(surf.get(0, 0));
+		quickLocs.add(surf.get(numRows-1, 0));
+		quickLocs.add(surf.get(0, numCols-1));
+		quickLocs.add(surf.get(numRows-1, numCols-1));
+		if (numCols > 2) {
+			quickLocs.add(surf.get(0, numCols/2));
+			quickLocs.add(surf.get(numRows-1, numCols/2));
+		}
+		quickLocs.add(getSurfaceMiddleLoc(surf));
+		
+		for (Location loc : quickLocs)
+			minDist = Math.min(minDist, LocationUtils.linearDistanceFast(siteLoc, loc));
+		return minDist;
+	}
+	
+	/**
+	 * Gets the center location of this surface. If it implements EvenlyGriddedSurface and has 3 or more
 	 * rows and columns, the center is directly retrieved. Otherwise the arithmetic average location of 
 	 * the evenly discretized location list is computed.
 	 * @param surf


### PR DESCRIPTION
I discovered that UCERF3 hazard curve calculations were spending most of their time performing the source.getMinDistance(loc) method, which bypassed all of the distance calculation caching. That distance was calculated to the corners of each individual subsection.

I added a new RuptureSurface.getQuickDistance(Location) method to RuptureSurface address this bottleneck, and also implemented a cache (see CacheEnabledSurface). Each surface can implement the quick distance in whichever way is most efficient, and the implementation for gridded surfaces is the same as before.

In core, I changed the getMinDistance(loc) method to use this method (and it's underlying cache), which sped up fault-source-only UCERF3 hazard curve calculation by a factor of ~8x (from 8 seconds to 1 second).